### PR TITLE
Removed space character between value and unit rem

### DIFF
--- a/styles/vendor/magento-ui/_utilities.scss
+++ b/styles/vendor/magento-ui/_utilities.scss
@@ -25,7 +25,7 @@
         @if $_value != false and $_value != '' {
             $_value: math.div(strip-unit($_value), $font-size-unit-ratio);
             @if $_value > 0 {
-                $_value: $_value * 1#{$font-size-unit};
+                $_value: #{$_value * 1}#{$font-size-unit};
             }
             @return $_value;
         }


### PR DESCRIPTION
This PR wil remove the space character between a value and a unit using the `lib-font-size-value` function.

https://github.com/creaminternet/magento2-theme-blank-sass/issues/11

